### PR TITLE
Fix issue #82: scikit-learn and requirement file update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-python >= 3.6
 torch >= 1.4.0
 matplotlib
-sympy = 1.4
+sympy >= 1.4
 pandas
+scikit-learn
 scipy
 sortedcontainers
 gfortran

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pandas
 scikit-learn
 scipy
 sortedcontainers
-gfortran

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=['matplotlib',
                       'numpy',
                       'seaborn',
-                      'sklearn',
+                      'scikit-learn',
                       'sortedcontainers',
                       'sympy >= 1.4',
                       'torch >= 1.4.0',


### PR DESCRIPTION
This PR fix Issue #82 

Like in issue #82, I have also tried to use the package on my Mac, but it seems the dependency of the lib is out-of-date.

There are two fix in this PR.

For local running of the lib:
  * The `requirement.txt` file is fixed with correct version requirements and package name.

For Setup.py for PIP install:
  * The `setup.py`'s dependency `sklearn` is corrected to `scikit-learn`.